### PR TITLE
Swapped markup creation to use jQuery, small CSS tweaks

### DIFF
--- a/css/swatches.css
+++ b/css/swatches.css
@@ -41,10 +41,10 @@
     left: 0;
     height: 10px;
     width: 100%;
-    background-color: black;
-    opacity: 0.15;
+    background-color: rgba(0,0,0,0.15);
     border-radius: 0 0 7px 7px;
     text-align: center;
+    color: rgba(0,0,0,0.4);
 }
 
 .color-names { 
@@ -55,8 +55,8 @@
 .name {
     display: inline-block;
     height: 100%;
-    margin-top: 4px;
     opacity: 0;
+    margin-top: 4px;
 }
 
 /* -----------------------------------------
@@ -66,4 +66,5 @@
     font-size: 20px;
     text-align: center;
     margin-top: 10px;
+    color: #000;
 }

--- a/css/swatches.css
+++ b/css/swatches.css
@@ -64,7 +64,6 @@
    ----------------------------------------- */
 .info {
     font-size: 20px;
-    font-weight: 150px;
     text-align: center;
     margin-top: 10px;
 }

--- a/jquery.swatches.js
+++ b/jquery.swatches.js
@@ -30,20 +30,23 @@
     // gimme some swatches!
     $.fn.swatchify = function() {
         this.each(function() {
-            var name = $(this).data('name');
-            var colors = $(this).data('colors').split(',');
-            var width = 100/colors.length + '%';
-            var infoContents = '<div class="shade"><div class="color-names">'
+            var target  = $(this);
+            var name    = target.data('name');
+            var colors  = target.data('colors').split(',');
+            var width   = 100/colors.length + '%';
 
-            var holder = '<div class="holder">';
-            for (i = 0; i < colors.length; i++) {
-                infoContents += '<span class="name">' + colors[i] + '</span>';
-                holder += '<span class="color" style="width:' + width + ';background-color:' + colors[i] + '"></span>';
+            var infoContents = $('<div/>', {class: 'shade'});
+            var holder       = $('<div/>', {class: 'holder'});
+
+            for (var i = 0; i < colors.length; i++) {
+                infoContents.append( $('<span/>', {class: 'name'}).css('width', width).text(colors[i]) );
+                holder.append( $('<span/>', {class: 'color'}).css({width: width, 'background-color': colors[i]}) );
             }
-            holder += infoContents + '</div></div></div>';
-            $(this).append(holder);
-            $(this).append('<div class="info">' + name + '</div>');
-            $(this).find('.name').each(function() { $(this).css('width', width) });
+
+            holder.append(infoContents);
+            target.append(holder);
+
+            target.append( $('<div/>', {class: 'info'}).text(name) );
         });
     };
 


### PR DESCRIPTION
Instead of using strings for markup, I've swapped in jQuery's element creation/manipulation machinery to make this easier to read, to maintain, and to configure.

Small CSS tweaks related to an invalid property value along with a less aggressive opacity solution (individual rgba values for background-color + text)
